### PR TITLE
fix: changing default model

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--model",
-        default='computer-use-preview-10-2025',
+        default='computer-use-exp',
         help="Set which main model to use.",
     )
     args = parser.parse_args()


### PR DESCRIPTION
The current default model `computer-use-preview-10-202` does not work, it throws

```
.../google/models/computer-use-preview-10-2025` not found.
```

The model `computer-use-exp` works.