### PR TITLE
Set default value of `press_enter` to `True` in `type_text_at` action

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -136,7 +136,7 @@ class BrowserAgent:
         elif action.name == "type_text_at":
             x = self.denormalize_x(action.args["x"])
             y = self.denormalize_y(action.args["y"])
-            press_enter = action.args.get("press_enter", False)
+            press_enter = action.args.get("press_enter", True)
             clear_before_typing = action.args.get("clear_before_typing", True)
             return self._browser_computer.type_text_at(
                 x=x,

--- a/test_agent.py
+++ b/test_agent.py
@@ -49,7 +49,7 @@ class TestBrowserAgent(unittest.TestCase):
         action = types.FunctionCall(name="type_text_at", args={"x": 100, "y": 200, "text": "hello"})
         self.agent.handle_action(action)
         self.mock_browser_computer.type_text_at.assert_called_once_with(
-            x=100, y=200, text="hello", press_enter=False, clear_before_typing=True
+            x=100, y=200, text="hello", press_enter=True, clear_before_typing=True
         )
 
     def test_handle_action_scroll_document(self):


### PR DESCRIPTION
Addresses #84 by following [official documentation](https://ai.google.dev/gemini-api/docs/computer-use#supported-actions)