### PR TITLE
Add Python 3.14 to the testing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,14 +27,14 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.x"]
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Automated testing should tell us if things are broken on the latest stable version of Python before users do.
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-input
> [x-ranges](https://github.com/npm/node-semver#x-ranges-12x-1x-12-) to specify the latest stable version of Python (for the specified major version): 