### PR TITLE
feat: add .env.example and python-dotenv support for easier local setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+
+GEMINI_API_KEY=your_gemini_api_key_here
+
+USE_VERTEXAI=false
+VERTEXAI_PROJECT=your_gcp_project_id
+VERTEXAI_LOCATION=us-central1
+
+
+PLAYWRIGHT_HEADLESS=false
+
+BROWSERBASE_API_KEY=your_browserbase_api_key_here
+BROWSERBASE_PROJECT_ID=your_browserbase_project_id_here

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ source .venv/bin/activate
 
 Replace `YOUR_PROJECT_ID` and `YOUR_LOCATION` with your actual project and location.
 
+#### C. Using a `.env` file (Recommended for local development):
+
+Copy the example environment file and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+Then open `.env` and replace the placeholder values with your actual API keys. The project will automatically load this file on startup — no need to manually export environment variables each session.
+
 ### 3. Running the Tool
 
 The primary way to use the tool is via the `main.py` script.

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ import argparse
 import os
 
 from dotenv import load_dotenv
-load_dotenv()  # .env dosyasını otomatik yükler
+load_dotenv()  # Load environment variables from .env file
 
 from agent import BrowserAgent
 from computers import BrowserbaseComputer, PlaywrightComputer

--- a/main.py
+++ b/main.py
@@ -14,6 +14,9 @@
 import argparse
 import os
 
+from dotenv import load_dotenv
+load_dotenv()  # .env dosyasını otomatik yükler
+
 from agent import BrowserAgent
 from computers import BrowserbaseComputer, PlaywrightComputer
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ playwright==1.55.0
 browserbase==1.4.0
 rich
 pytest
-python-dotenv
+python-dotenv==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ playwright==1.55.0
 browserbase==1.4.0
 rich
 pytest
+python-dotenv


### PR DESCRIPTION
- Adds [.env.example](cci:7://file:///C:/Users/muhammed/Desktop/googleproject/computer-use-preview/.env.example:0:0-0:0) as a template showing all required environment variables
- Adds `python-dotenv` so [.env](cci:7://file:///C:/Users/muhammed/Desktop/googleproject/computer-use-preview/.env:0:0-0:0) is automatically loaded on startup
- Updates README.md with a new "Using a .env file" section (Section C)
- Removes the need to manually export env vars each terminal session
